### PR TITLE
Kenchr/remove account

### DIFF
--- a/src/Libraries/ACMELib.Tests/TestSystem.cs
+++ b/src/Libraries/ACMELib.Tests/TestSystem.cs
@@ -12,7 +12,6 @@
     class TestSystem
     {
         private RSA rsaKey;
-        private string accountId = "123456";
         private Mock<IRestClient> restClient = new Mock<IRestClient>();
 
         public TestSystem()
@@ -22,12 +21,6 @@
         public TestSystem WithRSAKey(RSA key)
         {
             rsaKey = key;
-            return this;
-        }
-
-        public TestSystem WithAccountId(string accountId)
-        {
-            this.accountId = accountId;
             return this;
         }
 
@@ -52,7 +45,7 @@
             var restClientFactory = new Mock<IRestClientFactory>();
             restClientFactory.Setup(rcf => rcf.CreateRestClient(It.IsAny<Jws>())).Returns(restClient.Object);
 
-            var acmeClient = new ACMEClient(TestHelpers.baseUri.ToString(), rsaKey, accountId, restClientFactory.Object);
+            var acmeClient = new ACMEClient(TestHelpers.baseUri.ToString(), rsaKey, restClientFactory.Object);
             return (acmeClient, restClient);
         }
     }

--- a/src/Libraries/ACMELib/ACMEClient.cs
+++ b/src/Libraries/ACMELib/ACMEClient.cs
@@ -276,7 +276,7 @@
         /// <returns><see cref="ACMEDirectory"/></returns>
         public async Task<ACMEDirectory> GetDirectoryAsync(CancellationToken token = default)
         {
-            Directory = await RequestDirectoryAsync(token);
+            Directory = await RequestDirectoryAsync(token).ConfigureAwait(false);
             return Directory;
         }
 

--- a/src/Libraries/ACMELib/ACMELib.csproj
+++ b/src/Libraries/ACMELib/ACMELib.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <AssemblyName>Kenc.ACMELibCore</AssemblyName>
-    <RootNamespace>Kenc.ACMELibCore</RootNamespace>
+    <AssemblyName>Kenc.ACMELib</AssemblyName>
+    <RootNamespace>Kenc.ACMELib</RootNamespace>
 
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/src/Libraries/ACMELib/ACMERestClient.cs
+++ b/src/Libraries/ACMELib/ACMERestClient.cs
@@ -59,7 +59,7 @@
         /// <returns>a <typeparamref name="TResult"/> class with the result and a string containing the result.</returns>
         public async Task<(TResult Result, string Response)> GetAsync<TResult>(Uri uri, CancellationToken token) where TResult : class
         {
-            return await SendAsync<TResult>(HttpMethod.Get, uri, null, token);
+            return await SendAsync<TResult>(HttpMethod.Get, uri, null, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@
         /// <returns>a <typeparamref name="TResult"/> class with the result and a string containing the result.</returns>
         public async Task<(TResult result, string response)> HeadAsync<TResult>(Uri uri, CancellationToken token) where TResult : class
         {
-            return await SendAsync<TResult>(HttpMethod.Head, uri, null, token);
+            return await SendAsync<TResult>(HttpMethod.Head, uri, null, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@
         /// <returns>a <typeparamref name="TResult"/> class with the result and a string containing the result.</returns>
         public async Task<(TResult Result, string Response)> PostAsync<TResult>(Uri uri, object message, CancellationToken token) where TResult : class
         {
-            return await SendAsync<TResult>(HttpMethod.Post, uri, message, token);
+            return await SendAsync<TResult>(HttpMethod.Post, uri, message, token).ConfigureAwait(false);
         }
 
         private async Task<(TResult Result, string Response)> SendAsync<TResult>(HttpMethod method, Uri uri, object message, CancellationToken token) where TResult : class

--- a/src/Libraries/ACMELib/IACMEClient.cs
+++ b/src/Libraries/ACMELib/IACMEClient.cs
@@ -75,7 +75,7 @@
         /// <returns>A task representing the revoke action.</returns>
         /// <exception cref="Exceptions.API.UnauthorizedException">Thrown if the user isn't authorized to revoke the certificate.</exception>
         /// <exception cref="Exceptions.API.BadRevocationReasonException">Thrown if the <paramref name="revocationReason"/> isn't allowed.</exception>
-        Task RevokeCertificateAsync(X509Certificate2 certificate, RevocationReason revocationReason, CancellationToken cancellationToken = default);
+        Task RevokeCertificateAsync(X509Certificate certificate, RevocationReason revocationReason, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Request a certificate.

--- a/src/Libraries/ACMELib/JWS/Jws.cs
+++ b/src/Libraries/ACMELib/JWS/Jws.cs
@@ -49,8 +49,8 @@
 
             message.Signature = Base64UrlEncoded(
                 _rsa.SignData(Encoding.ASCII.GetBytes(message.Protected + "." + message.Payload),
-                                HashAlgorithmName.SHA256,
-                                RSASignaturePadding.Pkcs1));
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1));
 
             return message;
         }

--- a/src/Libraries/ACMELib/JWS/Jws.cs
+++ b/src/Libraries/ACMELib/JWS/Jws.cs
@@ -32,7 +32,7 @@
         public JwsMessage Encode<TPayload>(TPayload payload, JwsHeader protectedHeader)
         {
             protectedHeader.Algorithm = "RS256";
-            if (!string.IsNullOrEmpty(_jwk.KeyId))
+            if (!string.IsNullOrWhiteSpace(_jwk.KeyId))
             {
                 protectedHeader.KeyId = _jwk.KeyId;
             }
@@ -49,8 +49,8 @@
 
             message.Signature = Base64UrlEncoded(
                 _rsa.SignData(Encoding.ASCII.GetBytes(message.Protected + "." + message.Payload),
-                    HashAlgorithmName.SHA256,
-                    RSASignaturePadding.Pkcs1));
+                                HashAlgorithmName.SHA256,
+                                RSASignaturePadding.Pkcs1));
 
             return message;
         }


### PR DESCRIPTION
Convert all async/await calls in library to use .ConfigureAwait(false) 
Remove account it as argument in constructor
Use correct certificate data for certificate revocation request.
Change namespace for newly created files
Fix assembly name
adds revocation of certificates to example

fixes #2, fixes #3, fixes #4, fixes #5 