### PR TITLE
Fix multi-wildcard certificate requests

### DIFF
--- a/src/Examples/ACMEClient/Program.cs
+++ b/src/Examples/ACMEClient/Program.cs
@@ -170,7 +170,10 @@
                     continue;
                 }
 
-                foreach (var challenge in item.Challenges)
+                var applicableChallenges = item.Wildcard ? item.Challenges.Where(x => x.Type == "dns-01") :
+                    item.Challenges;
+
+                foreach (var challenge in applicableChallenges)
                 {
                     Console.WriteLine($"Status: {challenge.Status}");
                     Console.WriteLine($"Challenge: {challenge.Url}");

--- a/src/Libraries/ACMELib/ACMEClient.cs
+++ b/src/Libraries/ACMELib/ACMEClient.cs
@@ -223,20 +223,11 @@
         /// <remarks>The subjectname for the request is the first identifier in <paramref name="order"/>. Subsequent identifiers are added as alternative names.</remarks>
         public async Task<Order> RequestCertificateAsync(Order order, RSACryptoServiceProvider key, CancellationToken cancellationToken = default)
         {
-            List<string> identifiers = null;
-            if (order.Identifiers.Length > 1 && order.Identifiers[0].Value[0] == '*')
+            var identifiers = order.Identifiers.Select(item => item.Value).ToList();
+            if (identifiers.Any(x => x[0] == '*'))
             {
-                // wildcards always goes first in the response from lets encrypt; reverse the order as requesting a wildcard as the subject name fails.
-                identifiers = new List<string>
-                {
-                    order.Identifiers[1].Value,
-                    order.Identifiers[0].Value
-                };
-                identifiers.AddRange(order.Identifiers.Skip(2).Select(item => item.Value));
-            }
-            else
-            {
-                identifiers = order.Identifiers.Select(item => item.Value).ToList();
+                // ensure wildcards are at the end.
+                identifiers.Reverse();
             }
 
             var csr = new CertificateRequest("CN=" + identifiers.First(), key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);

--- a/src/Libraries/ACMELib/ACMERestClient.cs
+++ b/src/Libraries/ACMELib/ACMERestClient.cs
@@ -103,7 +103,7 @@
                 var json = JsonConvert.SerializeObject(encodedMessage, JsonSettings);
 
                 var stream = await request.GetRequestStreamAsync();
-                var encoded = UTF8Encoding.UTF8.GetBytes(json);
+                var encoded = Encoding.UTF8.GetBytes(json);
                 stream.Write(encoded, 0, encoded.Length);
                 stream.Close();
                 request.ContentLength = encoded.Length;


### PR DESCRIPTION
When generating certificate requests containing multiple wildcard domains, the request is rejected as wildcard can't be the default domain name, but has to be an alt-name.

In the current code, it checks if the first is a wildcard and swaps it with the 2nd item, regardless if the 2nd is also a wildcard.

When listing validations for wildcard domains, it currently shows all, however only DNS is accepted.
Ensure it only shows DNS in the sample.