### PR TITLE
Adding Directory.Build.Props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--
+    ********
+    WARNING: These targets support multiple frameworks.  Do not update the TargetFramework or any 
+             other framework specific items here as they will break the build.
+    ********
+    -->
+  <PropertyGroup>  
+    <FileAlignment>512</FileAlignment>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+
+  <!-- include Ken Christensen in all assemblies -->
+  <PropertyGroup>
+    <Company>Ken Christensen</Company>
+    <Product>Kenc.ACMELib</Product>
+    <Authors>Ken Christensen</Authors>
+    <Copyright>© 2019 Ken Christensen. All rights reserved.</Copyright>
+  </PropertyGroup>
+
+  <!-- Saving some paths that are used elsewhere in MSBuild settings and targets -->
+  <PropertyGroup>
+    <OutputSubdir Condition=" '$(OutputSubDir)' == ''">$(MSBuildProjectName)</OutputSubdir>
+
+    <EnlistmentRoot>$(MSBuildThisFileDirectory)</EnlistmentRoot>
+    <EnlistmentRoot Condition="!HasTrailingSlash('$(EnlistmentRoot)')">$(EnlistmentRoot)\</EnlistmentRoot>
+    <MSBuildOverrides>$(MSBuildToolsPath)</MSBuildOverrides>
+    
+    <!-- setup intermediate folder to be root\Intermedia\ with unique subfolder paths -->
+    <IntermediateRootPath>$(EnlistmentRoot)Intermediates</IntermediateRootPath>
+    <IntermediateOutputPath>$(IntermediateRootPath)\$(Configuration)\$(Platform)\$(OutputSubdir)</IntermediateOutputPath>
+
+    <OutputRootPath>$(EnlistmentRoot)Drops</OutputRootPath>
+    <OutputPath>$(OutputRootPath)\$(Configuration)\$(Platform)\$(OutputSubdir)</OutputPath>
+
+    <!-- Add generated xml documentation files to packaged project output -->
+    <ExcludeXmlAssemblyFiles>false</ExcludeXmlAssemblyFiles>
+  </PropertyGroup>
+</Project>

--- a/src/ACME.sln
+++ b/src/ACME.sln
@@ -1,15 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2002
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29306.81
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{C9A9AB54-D122-48CC-9CA7-F34BC5DB3293}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ACMEClient", "Examples\ACMEClient\ACMEClient.csproj", "{BD4872DB-73DF-497D-915D-C20EB4283167}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ACMELib", "Libraries\ACMELib\ACMELib.csproj", "{1008A2AB-B3BD-4C83-970C-DEEF51E90668}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kenc.ACMELib", "Libraries\ACMELib\Kenc.ACMELib.csproj", "{1008A2AB-B3BD-4C83-970C-DEEF51E90668}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ACMELibCore.Tests", "Libraries\ACMELib.Tests\ACMELibCore.Tests.csproj", "{180FB53E-F43A-454E-9B4D-3653B8B0170E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kenc.ACMELibCore.Tests", "Libraries\ACMELib.Tests\Kenc.ACMELibCore.Tests.csproj", "{180FB53E-F43A-454E-9B4D-3653B8B0170E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Examples/ACMEClient/ACMEClient.csproj
+++ b/src/Examples/ACMEClient/ACMEClient.csproj
@@ -3,11 +3,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Libraries\ACMELib\ACMELib.csproj" />
+    <ProjectReference Include="..\..\Libraries\ACMELib\Kenc.ACMELib.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Libraries/ACMELib.Tests/Kenc.ACMELibCore.Tests.csproj
+++ b/src/Libraries/ACMELib.Tests/Kenc.ACMELibCore.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ACMELib\ACMELib.csproj" />
+    <ProjectReference Include="..\ACMELib\Kenc.ACMELib.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Libraries/ACMELib/Kenc.ACMELib.csproj
+++ b/src/Libraries/ACMELib/Kenc.ACMELib.csproj
@@ -1,33 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
-    <AssemblyName>Kenc.ACMELib</AssemblyName>
-    <RootNamespace>Kenc.ACMELib</RootNamespace>
-
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
-  <!-- nuget package properties -->
+  </PropertyGroup>  
   <PropertyGroup>
+    <Description>.net core library for communicating with Let’s Encrypt ACME servers for certificate management.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>Ken Christensen</Authors>
-    <Company>Ken Christensen</Company>
+    
+    <!-- nuget package properties -->
     <PackageId>Kenc.ACMELib</PackageId>
-    <Product>Kenc.ACMELib</Product>
+    <PackageId>Kenc.ACMELib</PackageId>
+    <PackageTags>ACME LetsEncrypt Certificate</PackageTags>
     <PackageDescription>ACME v2 compliant client implementation</PackageDescription>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/Kencdk/Kenc.ACMELib/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 
     <!-- source link properties -->
+    <RepositoryType>Github</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PackageProjectUrl>https://github.com/Kencdk/Kenc.ACMELib</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Kencdk/Kenc.ACMELib</RepositoryUrl>
-    <RepositoryType>Github</RepositoryType>
-    <PackageTags>ACME LetsEncrypt Certificate</PackageTags>
-    <Copyright>2018 Ken Christensen</Copyright>
-    <Description>.net core library for communicating with Let’s Encrypt ACME servers for certificate management.</Description>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="..\..\..\LICENSE" Link="LICENSE">
@@ -35,7 +28,6 @@
       <PackagePath>\</PackagePath>
     </Content>
   </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />


### PR DESCRIPTION
Ensure custom build properties are set in Directory.Build.Props
Redirect Intermediate and drops folder outputs.
Rename .csproj files
Update SLN to 2019.