### PR TITLE
Add Drops & Intermediates to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+Drops/
+Intermediates/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/


### PR DESCRIPTION
After build scripts were added to redirect intermediate and drops output to /Intermediate & /Drops, however they weren't added to .gitignore.

Add Drops & Intermediates to .gitignore