### PR TITLE
Support using subdomains with cloudflare integration

### DIFF
--- a/src/Examples/CloudflareIntegration/OrderDomains.cs
+++ b/src/Examples/CloudflareIntegration/OrderDomains.cs
@@ -68,7 +68,7 @@
 
         public async Task ValidateCloudflareConnection()
         {
-            var cleanedupDomains = options.Domains.Select(x => (x.StartsWith('*') ? x.Substring(2) : x).ToLowerInvariant())
+            var cleanedupDomains = options.Domains.Select(GetRootDomain)
                 .Distinct()
                 .ToList();
 
@@ -262,6 +262,17 @@
             Program.LogLine($"Private certificate written to file {privateKeyFilename}");
         }
 
+        /// <summary>
+        /// Get the root (domain.tld) from a given domain (eg: subdomain.domain.tld)
+        /// </summary>
+        /// <param name="domain">Target domain</param>
+        /// <returns>A string with the root domain incl the top-level-domain</returns>
+        private static string GetRootDomain(string domain)
+        {
+            var parts = domain.ToLowerInvariant().Split('.');
+            return string.Join('.', parts.TakeLast(2));
+        }
+
         private static string FixFilename(string filename)
         {
             return filename.Replace("*", "");
@@ -301,7 +312,7 @@
             var dnsRecordName = $"_acme-challenge.{domain}";
 
             Program.LogLine($"Adding TXT entry {dnsRecordName} with value {value}", true);
-            Zone cloudflareZone = CloudflareZones.GetValueOrDefault(domain);
+            Zone cloudflareZone = CloudflareZones.GetValueOrDefault(GetRootDomain(domain));
 
             DNSRecord dnsRecord;
             try

--- a/src/Examples/CloudflareIntegration/Program.cs
+++ b/src/Examples/CloudflareIntegration/Program.cs
@@ -5,6 +5,7 @@
     using System.IO;
     using System.Threading.Tasks;
     using CommandLine;
+    using Kenc.ACMELib.ACMEEntities;
 
     class Program
     {
@@ -35,10 +36,10 @@
             var orderDomains = new OrderDomains(options);
             await orderDomains.ValidateCloudflareConnection();
             await orderDomains.ValidateACMEConnection();
-            var order = await orderDomains.ValidateDomains();
+
+            Order order = await orderDomains.ValidateDomains();
             order = await orderDomains.ValidateOrder(order);
             await orderDomains.RetrieveCertificates(order);
-
         }
 
         static void HandleParseError(IEnumerable<Error> errs)

--- a/src/Libraries/ACMELib.Tests/Kenc.ACMELibCore.Tests.csproj
+++ b/src/Libraries/ACMELib.Tests/Kenc.ACMELibCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>

--- a/src/Libraries/ACMELib/Kenc.ACMELib.csproj
+++ b/src/Libraries/ACMELib/Kenc.ACMELib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>  
   <PropertyGroup>
     <Description>.net core library for communicating with Let’s Encrypt ACME servers for certificate management.</Description>


### PR DESCRIPTION
Fixing #25 

Cloudflare uses the root domain for interacting with the API.
Ensure interactions with the API uses the root domain.

