### PR TITLE
Add PEM support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     -->
   <PropertyGroup>  
     <FileAlignment>512</FileAlignment>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <!-- include Ken Christensen in all assemblies -->
@@ -16,7 +16,7 @@
     <Company>Ken Christensen</Company>
     <Product>Kenc.ACMELib</Product>
     <Authors>Ken Christensen</Authors>
-    <Copyright>© 2021 Ken Christensen. All rights reserved.</Copyright>
+    <Copyright>© 2022 Ken Christensen. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <!-- Saving some paths that are used elsewhere in MSBuild settings and targets -->

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+      "version": "7.0.0",
+      "rollForward": "latestFeature",
+      "allowPrerelease": false
+    }
+  }

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    </packageSources>
+</configuration>

--- a/src/Examples/ACMEClient/ACMEClient.csproj
+++ b/src/Examples/ACMEClient/ACMEClient.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <LangVersion>9.0</LangVersion>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examples/ACMEClient/PasswordInput.cs
+++ b/src/Examples/ACMEClient/PasswordInput.cs
@@ -9,7 +9,7 @@
     /// <summary>
     /// Based on https://stackoverflow.com/questions/3404421/password-masking-console-application
     /// </summary>
-    internal class PasswordInput
+    internal partial class PasswordInput
     {
         private enum StdHandle
         {
@@ -26,16 +26,16 @@
         private const int ENTER = 13, BACKSP = 8, CTRLBACKSP = 127;
         private static readonly int[] Filtered = { 0, 27 /* escape */, 9 /*tab*/, 10 /* line feed */ };
 
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern IntPtr GetStdHandle(StdHandle nStdHandle);
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        private static partial IntPtr GetStdHandle(StdHandle nStdHandle);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [LibraryImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out int lpMode);
+        private static partial bool GetConsoleMode(IntPtr hConsoleHandle, out int lpMode);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [LibraryImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool SetConsoleMode(IntPtr hConsoleHandle, int dwMode);
+        private static partial bool SetConsoleMode(IntPtr hConsoleHandle, int dwMode);
 
         public static SecureString ReadPassword()
         {

--- a/src/Examples/CloudflareIntegration/CertificateExportFormat.cs
+++ b/src/Examples/CloudflareIntegration/CertificateExportFormat.cs
@@ -1,0 +1,8 @@
+﻿namespace CloudflareIntegration
+{
+    public enum CertificateExportFormat
+    {
+        PFX,
+        PEM,
+    }
+}

--- a/src/Examples/CloudflareIntegration/CloudflareIntegration.csproj
+++ b/src/Examples/CloudflareIntegration/CloudflareIntegration.csproj
@@ -2,14 +2,15 @@
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.79" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <LangVersion>9.0</LangVersion>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="DnsClient" />
     <PackageReference Include="Kenc.Cloudflare" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples/CloudflareIntegration/Options.cs
+++ b/src/Examples/CloudflareIntegration/Options.cs
@@ -22,5 +22,8 @@
 
         [Option('k', "key", Required = false, HelpText = "RSA key to use for authenticating with ACME")]
         public string Key { get; set; }
+
+        [Option('f', "format", Required = false, HelpText = "Format to export certificate as.")]
+        public CertificateExportFormat ExportFormat { get; set; } = CertificateExportFormat.PFX;
     }
 }

--- a/src/Examples/CloudflareIntegration/PasswordInput.cs
+++ b/src/Examples/CloudflareIntegration/PasswordInput.cs
@@ -9,7 +9,7 @@
     /// <summary>
     /// Based on https://stackoverflow.com/questions/3404421/password-masking-console-application
     /// </summary>
-    internal class PasswordInput
+    internal partial class PasswordInput
     {
         private enum StdHandle
         {
@@ -26,16 +26,16 @@
         private const int ENTER = 13, BACKSP = 8, CTRLBACKSP = 127;
         private static readonly int[] Filtered = { 0, 27 /* escape */, 9 /*tab*/, 10 /* line feed */ };
 
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern IntPtr GetStdHandle(StdHandle nStdHandle);
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        private static partial IntPtr GetStdHandle(StdHandle nStdHandle);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [LibraryImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out int lpMode);
+        private static partial bool GetConsoleMode(IntPtr hConsoleHandle, out int lpMode);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [LibraryImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool SetConsoleMode(IntPtr hConsoleHandle, int dwMode);
+        private static partial bool SetConsoleMode(IntPtr hConsoleHandle, int dwMode);
 
         public static SecureString ReadPassword()
         {

--- a/src/Libraries/ACMELib.Tests/Kenc.ACMELibCore.Tests.csproj
+++ b/src/Libraries/ACMELib.Tests/Kenc.ACMELibCore.Tests.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.79" />
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libraries/ACMELib.Tests/Mocks/CertificateMock.cs
+++ b/src/Libraries/ACMELib.Tests/Mocks/CertificateMock.cs
@@ -6,10 +6,12 @@
     {
         private readonly string publicKeyString;
 
+#pragma warning disable SYSLIB0026 // Type or member is obsolete
         public CertificateMock(string publicKeyString)
         {
             this.publicKeyString = publicKeyString;
         }
+#pragma warning restore SYSLIB0026 // Type or member is obsolete
 
         public override string GetPublicKeyString()
         {

--- a/src/Libraries/ACMELib.Tests/Mocks/TestHttpMessageHandler.cs
+++ b/src/Libraries/ACMELib.Tests/Mocks/TestHttpMessageHandler.cs
@@ -8,7 +8,7 @@
 
     public class TestHttpMessageHandler : HttpMessageHandler
     {
-        private Dictionary<Uri, Func<HttpRequestMessage, HttpResponseMessage>> responses = new Dictionary<Uri, Func<HttpRequestMessage, HttpResponseMessage>>();
+        private readonly Dictionary<Uri, Func<HttpRequestMessage, HttpResponseMessage>> responses = new();
 
         public virtual HttpResponseMessage Send(HttpRequestMessage request)
         {
@@ -17,9 +17,9 @@
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (responses.ContainsKey(request.RequestUri))
+            if (responses.TryGetValue(request.RequestUri, out Func<HttpRequestMessage, HttpResponseMessage> value))
             {
-                var result = responses[request.RequestUri].Invoke(request);
+                HttpResponseMessage result = value.Invoke(request);
                 return Task.FromResult(result);
             }
 
@@ -32,7 +32,9 @@
             return this;
         }
 
+#pragma warning disable IDE0060 // Remove unused parameter
         public TestHttpMessageHandler WithDirectory(Uri uri)
+#pragma warning restore IDE0060 // Remove unused parameter
         {
             return this;
         }

--- a/src/Libraries/ACMELib.Tests/TestHelpers.cs
+++ b/src/Libraries/ACMELib.Tests/TestHelpers.cs
@@ -13,10 +13,10 @@
 
     public static class TestHelpers
     {
-        public static Uri BaseUri = new Uri("https://acmetest.invalid");
-        public static Uri DirectoryUri = new Uri(BaseUri, "directory");
+        public static readonly Uri BaseUri = new("https://acmetest.invalid");
+        public static readonly Uri DirectoryUri = new(BaseUri, "directory");
 
-        public static ACMEDirectory AcmeDirectory = new ACMEDirectory
+        public static readonly ACMEDirectory AcmeDirectory = new()
         {
             KeyChange = new Uri(BaseUri, "keyChange"),
             Meta = new DirectoryMeta

--- a/src/Libraries/ACMELib.Tests/TestSystem.cs
+++ b/src/Libraries/ACMELib.Tests/TestSystem.cs
@@ -14,7 +14,7 @@
     internal class TestSystem
     {
         private RSA rsaKey;
-        private readonly Mock<HttpClient> restClient = new Mock<HttpClient>();
+        private readonly Mock<HttpClient> restClient = new();
 
         public TestSystem()
         {
@@ -70,10 +70,7 @@
 
         public (ACMEClient, Mock<HttpClient>) Build()
         {
-            if (rsaKey == null)
-            {
-                rsaKey = RSA.Create();
-            }
+            rsaKey ??= RSA.Create();
 
             var acmeClient = new ACMEClient(TestHelpers.BaseUri, rsaKey, restClient.Object);
             return (acmeClient, restClient);

--- a/src/Libraries/ACMELib/Kenc.ACMELib.csproj
+++ b/src/Libraries/ACMELib/Kenc.ACMELib.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.79" />
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>  
   <PropertyGroup>

--- a/src/Packages.props
+++ b/src/Packages.props
@@ -1,25 +1,26 @@
 <Project>
     <ItemGroup>
         <!-- net framework packages -->
-        <PackageReference Update="Microsoft.Extensions.Http" Version="6.0.0" />
-        <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-        <PackageReference Update="System.Text.Json" Version="6.0.5" />
+        <PackageReference Update="Microsoft.Extensions.Configuration" Version="7.0.0" />
+        <PackageReference Update="Microsoft.Extensions.Http" Version="7.0.0" />
+        <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+        <PackageReference Update="System.Text.Json" Version="7.0.1" />
 
         <!-- other libraries -->
         <PackageReference Update="CommandLineParser" Version="2.9.1" />
-        <PackageReference Update="DnsClient" Version="1.6.1" />
+        <PackageReference Update="DnsClient" Version="1.7.0" />
         <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-        <PackageReference Update="Kenc.Cloudflare" Version="0.0.514.3" />
+        <PackageReference Update="Kenc.Cloudflare" Version="0.1.8-beta" />
 
         <!-- Test libraries -->
-        <PackageReference Update="FluentAssertions" Version="6.7.0" />
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Update="Moq" Version="4.18.1" />
-        <PackageReference Update="MSTest.TestAdapter" Version="2.2.10" />
-        <PackageReference Update="MSTest.TestFramework" Version="2.2.10" />
+        <PackageReference Update="FluentAssertions" Version="6.8.0" />
+        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Update="Moq" Version="4.18.3" />
+        <PackageReference Update="MSTest.TestAdapter" Version="3.0.2" />
+        <PackageReference Update="MSTest.TestFramework" Version="3.0.2" />
 
         <!-- Static analysis -->
-        <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+        <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </GlobalPackageReference>


### PR DESCRIPTION
Add an option to specify the output format of the certificate.
When PEM is selected, three files are generated.
{certname}.key.pem with the private key
{certname}.cert.pem with the certificate
{certname}.chain.pem with the certificate chain

Also updates the project to build using the .net 7 toolchain
The library is still targeting .net standard 2.1 whereas the test and example projects are targeting .net 7.