### PR TITLE
Extend Directory

### DIFF
--- a/src/Libraries/ACMELib/ACMEResponses/Directory.cs
+++ b/src/Libraries/ACMELib/ACMEResponses/Directory.cs
@@ -1,6 +1,8 @@
 ﻿namespace Kenc.ACMELib.ACMEResponses
 {
     using System;
+    using System.Collections.Generic;
+    using System.Text.Json;
     using System.Text.Json.Serialization;
 
     /// <summary>
@@ -28,11 +30,29 @@
 
         [JsonPropertyName("meta")]
         public DirectoryMeta Meta { get; set; }
+
+        [JsonPropertyName("renewalInfo")]
+        public Uri RenewalInfo { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> ExtensionData { get; set; }
     }
 
     public class DirectoryMeta
     {
         [JsonPropertyName("termsOfService")]
         public string TermsOfService { get; set; }
+
+        [JsonPropertyName("website")]
+        public Uri Website { get; set; }
+
+        [JsonPropertyName("caaIdentities")]
+        public IReadOnlyList<string> CaaIdentities { get; set; }
+
+        [JsonPropertyName("profiles")]
+        public IReadOnlyDictionary<string, Uri> Profiles { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> ExtensionData { get; set; }
     }
 }


### PR DESCRIPTION
Since the introduction of the ACME protocol, new fields have been added to the directory object through extensions. These are not present in current versions of Kenc.ACMELib.

* Add missing fields
* Add ExtensionData dictionary, unblocking developers by being a catch-all for missing directory fields.